### PR TITLE
Add console output for manual session.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,12 @@ export const jasmineTestRunnerConfig = () => {
                     });
                   });
   
-                  if (result.status !== 'passed' || result.status !== 'incomplete') {
+
+                const isManualSession = new URL(result.filename).searchParams.get('wtr-manual-session') === 'true';
+                if (isManualSession) {
+                  console.log(result.status.toUpperCase(), result.fullName);
+                }
+                if (result.status !== 'passed' || result.status !== 'incomplete') {
                     result.failedExpectations.forEach(e => {
                       failedSpecs.push({
                         message: result.fullName + ': ' + e.message,
@@ -74,6 +79,9 @@ export const jasmineTestRunnerConfig = () => {
                         expected: e.expected,
                         actual: e.actual,
                       });
+                      if (isManualSession) {
+                        console.error(e.message, e.stack ? '\\n' + e.stack : '');
+                      }
                     });
                   }
                 },


### PR DESCRIPTION
When my tests fail I run web-test-runner in manual mode so I can attach a web browser and debug with dev tools. Currently tests produce no output either to the test page or the JavaScript console, so it isn't obvious how changes to the code affect test status without adding logging breakpoints or calls.

This PR adds console output only when the test is in manual mode so the extra logging doesn't show up in web-test-runner reporters. It logs the result of each spec and for failed specs it shows details of the failing check.

![Screenshot 2024-04-28 at 11 38 42 AM](https://github.com/blueprintui/web-test-runner-jasmine/assets/156154/e5c588c3-6bf2-445a-b2da-8bc84ff2092e)
