### PR TITLE
Allow passing configuration options to Jasmine

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -158,6 +158,8 @@ env.addReporter({
   }
 
   try {
+    env.configure(config);
+
     await import(new URL(testFile, document.baseURI).href);
 
     // Run jasmine.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ export interface JasmineConfig {
   defaultTimeoutInterval?: number;
   /** @deprecated use defaultTimeoutInterval */
   timeout?: number;
-  styles?: []
+  styles?: [];
+  random: boolean;
+  seed: number|string;
 }
 
 export const jasmineTestRunnerConfig = () => {


### PR DESCRIPTION
I've been debugging some specs that only fail when run in a specific order. An easy way to debug this is to pass the [seed](https://jasmine.github.io/api/edge/Configuration.html#seed) option to Jasmine to ensure you always see the failure. This PR makes that possible. Anything added to the `testFramework.config` object in the `web-test-runner.config.js` file is passed to Jasmine.

I'm not sure if every configuration option Jasmine provides will work as expected with this adapter, but `random` and `seed` should be okay to use, so I also added type definitions for them.