### PR TITLE
Adjust Node version compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "packageManager": "pnpm@10.11.0",
   "engines": {
-    "node": "^22.15.1"
+    "node": ">=22.15.1"
   },
   "scripts": {
     "ci": "pnpm run clean && pnpm run build && pnpm run test",


### PR DESCRIPTION
Closes #26 

- Enable support for version v22.15.1 and greater instead of v22.15.1 and greater, but lower than v23.
- Enable support for new LTS (v24)