### PR TITLE
Jasmine 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "ansi-colors": "4.1.3"
   },
   "peerDependencies": {
-    "jasmine": "^5.8.0",
-    "jasmine-core": "^5.8.0"
+    "jasmine-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^5.1.8",
@@ -46,8 +45,7 @@
     "@web/test-runner-playwright": "0.11.1",
     "cpy-cli": "5.0.0",
     "esbuild": "^0.25.6",
-    "jasmine": "^5.8.0",
-    "jasmine-core": "^5.8.0",
+    "jasmine-core": "^6.0.0",
     "playwright": "1.53.2",
     "typescript": "5.7.3",
     "unenv": "^1.10.0"

--- a/src/console-reporter.ts
+++ b/src/console-reporter.ts
@@ -1,0 +1,321 @@
+// @ts-nocheck
+
+/*
+Copyright (c) 2014-2019 Pivotal Labs
+Copyright (c) 2014-2026 The Jasmine developers
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/**
+ * @classdesc A reporter that prints spec and suite results to the console.
+ * A ConsoleReporter is installed by default.
+ *
+ * @constructor
+ * @example
+ * const {ConsoleReporter} = require('jasmine');
+ * const reporter = new ConsoleReporter();
+ */
+export default function ConsoleReporter() {
+  let print = function() {},
+    showColors = false,
+    specCount,
+    executableSpecCount,
+    failureCount,
+    failedSpecs = [],
+    pendingSpecs = [],
+    alwaysListPendingSpecs = true,
+    ansi = {
+      green: '\x1B[32m',
+      red: '\x1B[31m',
+      yellow: '\x1B[33m',
+      none: '\x1B[0m'
+    },
+    failedSuites = [],
+    stackFilter = stack => stack;
+
+  /**
+   * Configures the reporter.
+   * @function
+   * @name ConsoleReporter#setOptions
+   * @param {ConsoleReporterOptions} options
+   */
+  this.setOptions = function(options) {
+    if (options.print) {
+      print = options.print;
+    }
+
+    /**
+     * @interface ConsoleReporterOptions
+     */
+    /**
+     * Whether to colorize the output
+     * @name ConsoleReporterOptions#showColors
+     * @type Boolean|undefined
+     * @default false
+     */
+    showColors = options.showColors || false;
+    if (options.stackFilter) {
+      stackFilter = options.stackFilter;
+    }
+    /**
+     * A function that takes a random seed and returns the command to reproduce
+     * that seed. Use this to customize the output when using ConsoleReporter
+     * in a different command line tool.
+     * @name ConsoleReporterOptions#randomSeedReproductionCmd
+     * @type Function|undefined
+     */
+    if (options.randomSeedReproductionCmd) {
+      this.randomSeedReproductionCmd = options.randomSeedReproductionCmd;
+    }
+
+    /**
+     * Whether to list pending specs even if there are failures.
+     * @name ConsoleReporterOptions#alwaysListPendingSpecs
+     * @type Boolean|undefined
+     * @default true
+     */
+    if (options.alwaysListPendingSpecs !== undefined) {
+      alwaysListPendingSpecs = options.alwaysListPendingSpecs;
+    }
+  };
+
+  this.jasmineStarted = function(options) {
+    specCount = 0;
+    executableSpecCount = 0;
+    failureCount = 0;
+    if (options && options.order && options.order.random) {
+      print('Randomized with seed ' + options.order.seed);
+      printNewline();
+    }
+    print('Started');
+    printNewline();
+  };
+
+  this.jasmineDone = function(result) {
+    if (result.failedExpectations) {
+      failureCount += result.failedExpectations.length;
+    }
+
+    printNewline();
+    printNewline();
+    if (failedSpecs.length > 0) {
+      print('Failures:');
+    }
+    for (let i = 0; i < failedSpecs.length; i++) {
+      specFailureDetails(failedSpecs[i], i + 1);
+    }
+
+    for(let i = 0; i < failedSuites.length; i++) {
+      suiteFailureDetails(failedSuites[i]);
+    }
+
+    if (result && result.failedExpectations && result.failedExpectations.length > 0) {
+      suiteFailureDetails({ fullName: 'top suite', ...result });
+    }
+
+    if (alwaysListPendingSpecs || result.overallStatus === 'passed') {
+      if (pendingSpecs.length > 0) {
+        print("Pending:");
+      }
+      for (let i = 0; i < pendingSpecs.length; i++) {
+        pendingSpecDetails(pendingSpecs[i], i + 1);
+      }
+    }
+
+    if(specCount > 0) {
+      printNewline();
+
+      if(executableSpecCount !== specCount) {
+        print('Ran ' + executableSpecCount + ' of ' + specCount + plural(' spec', specCount));
+        printNewline();
+      }
+      let specCounts = executableSpecCount + ' ' + plural('spec', executableSpecCount) + ', ' +
+        failureCount + ' ' + plural('failure', failureCount);
+
+      if (pendingSpecs.length) {
+        specCounts += ', ' + pendingSpecs.length + ' pending ' + plural('spec', pendingSpecs.length);
+      }
+
+      print(specCounts);
+    } else {
+      print('No specs found');
+    }
+
+    printNewline();
+
+    if (result.numWorkers) {
+      print('Ran in parallel with ' + result.numWorkers + ' workers');
+      printNewline();
+    }
+
+    const seconds = result ? result.totalTime / 1000 : 0;
+    print('Finished in ' + seconds + ' ' + plural('second', seconds));
+    printNewline();
+
+    if (result && result.overallStatus === 'incomplete') {
+      print('Incomplete: ' + result.incompleteReason);
+      printNewline();
+    }
+
+    if (result && result.order && result.order.random) {
+      print('Randomized with seed ' + result.order.seed);
+      print(' (' + this.randomSeedReproductionCmd(result.order.seed) + ')');
+      printNewline();
+    }
+  };
+
+  this.randomSeedReproductionCmd = function(seed) {
+    return 'jasmine --random=true --seed=' + seed;
+  };
+
+  this.specDone = function(result) {
+    specCount++;
+
+    if (result.status == 'pending') {
+      pendingSpecs.push(result);
+      executableSpecCount++;
+      print(colored('yellow', '*'));
+      return;
+    }
+
+    if (result.status == 'passed') {
+      executableSpecCount++;
+      print(colored('green', '.'));
+      return;
+    }
+
+    if (result.status == 'failed') {
+      failureCount++;
+      failedSpecs.push(result);
+      executableSpecCount++;
+      print(colored('red', 'F'));
+    }
+  };
+
+  this.suiteDone = function(result) {
+    if (result.failedExpectations && result.failedExpectations.length > 0) {
+      failureCount++;
+      failedSuites.push(result);
+    }
+  };
+
+  this.reporterCapabilities = {parallel: true};
+
+  return this;
+
+  function printNewline() {
+    print('\n');
+  }
+
+  function colored(color, str) {
+    return showColors ? (ansi[color] + str + ansi.none) : str;
+  }
+
+  function plural(str, count) {
+    return count == 1 ? str : str + 's';
+  }
+
+  function repeat(thing, times) {
+    const arr = [];
+    for (let i = 0; i < times; i++) {
+      arr.push(thing);
+    }
+    return arr;
+  }
+
+  function indent(str, spaces) {
+    const lines = (str || '').split('\n');
+    const newArr = [];
+    for (let i = 0; i < lines.length; i++) {
+      newArr.push(repeat(' ', spaces).join('') + lines[i]);
+    }
+    return newArr.join('\n');
+  }
+
+  function specFailureDetails(result, failedSpecNumber) {
+    printNewline();
+    print(failedSpecNumber + ') ');
+    print(result.fullName);
+    printFailedExpectations(result);
+
+    if (result.debugLogs) {
+      printNewline();
+      print(indent('Debug logs:', 2));
+      printNewline();
+
+      for (const entry of result.debugLogs) {
+        print(indent(`${entry.timestamp}ms: ${entry.message}`, 4));
+        printNewline();
+      }
+    }
+  }
+
+  function suiteFailureDetails(result) {
+    printNewline();
+    print('Suite error: ' + result.fullName);
+    printFailedExpectations(result);
+  }
+
+  function printFailedExpectations(result) {
+    for (let i = 0; i < result.failedExpectations.length; i++) {
+      const failedExpectation = result.failedExpectations[i];
+      printNewline();
+      print(indent('Message:', 2));
+      printNewline();
+      print(colored('red', indent(failedExpectation.message, 4)));
+      printNewline();
+      print(indent('Stack:', 2));
+      printNewline();
+      print(indent(stackFilter(failedExpectation.stack), 4));
+    }
+
+    // When failSpecWithNoExpectations = true and a spec fails because of no expectations found,
+    // jasmine-core reports it as a failure with no message.
+    //
+    // Therefore we assume that when there are no failed or passed expectations,
+    // the failure was because of our failSpecWithNoExpectations setting.
+    //
+    // Same logic is used by jasmine.HtmlReporter, see https://github.com/jasmine/jasmine/blob/main/src/html/HtmlReporter.js
+    if (result.failedExpectations.length === 0 &&
+      result.passedExpectations.length === 0) {
+      printNewline();
+      print(indent('Message:', 2));
+      printNewline();
+      print(colored('red', indent('Spec has no expectations', 4)));
+    }
+
+    printNewline();
+  }
+
+  function pendingSpecDetails(result, pendingSpecNumber) {
+    printNewline();
+    printNewline();
+    print(pendingSpecNumber + ') ');
+    print(result.fullName);
+    printNewline();
+    let pendingReason = "No reason given";
+    if (result.pendingReason && result.pendingReason !== '') {
+      pendingReason = result.pendingReason;
+    }
+    print(indent(colored('yellow', pendingReason), 2));
+    printNewline();
+  }
+}

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -2,24 +2,19 @@
 
 import assert from 'assert';
 import { getConfig, sessionFailed, sessionFinished, sessionStarted, TestResultError, TestSuiteResult } from '@web/test-runner-core/browser/session.js';
-import Jasmine from 'jasmine';
 import { yellow } from 'ansi-colors';
 
 import type { JasmineConfig } from './index';
 import { findParentNode, findResultNode, isSuiteNode, SpecNode, SuiteNode } from './jasmine-suite-nodes';
-
-// Needed for Jasmine to pick up Windows as `jasmineGlobal`.
-window.global = window;
+// @ts-ignore
+import ConsoleReporter from './console-reporter';
 
 // @ts-ignore
-const jasmineRequire = await import('jasmine-core/lib/jasmine-core/jasmine.js');
-const jasmine = jasmineRequire.core(jasmineRequire);
-const global = jasmine.getGlobal();
-global.jasmine = jasmine;
+window.jasmine = jasmineRequire.core(jasmineRequire);
 const env: jasmine.Env = jasmine.getEnv();
 
+// @ts-ignore
 Object.assign(window, jasmineRequire.interface(jasmine, env));
-window.onload = function () { };
 
 const buildTestResults = (jasmineTreeNode: SpecNode|SuiteNode): TestSuiteResult => {
   const treeNode: TestSuiteResult = {
@@ -137,12 +132,16 @@ env.addReporter({
 (async () => {
   sessionStarted();
   const { testFile, debug, testFrameworkConfig } = await getConfig();
-  const config = { defaultTimeoutInterval: 5000, ...(testFrameworkConfig ?? {}) } as JasmineConfig;
+  const config: JasmineConfig = testFrameworkConfig ?? {};
+  if (config.defaultTimeoutInterval === undefined) {
+    config.defaultTimeoutInterval = 500;
+  }
 
   jasmine.DEFAULT_TIMEOUT_INTERVAL = config.defaultTimeoutInterval;
 
   if (debug) {
-    const consoleReporter = Jasmine.ConsoleReporter();
+    // @ts-ignore
+    const consoleReporter = new ConsoleReporter();
     let stdout = '';
     consoleReporter.setOptions({
       print: (t: string) => stdout += t,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export const jasmineTestRunnerConfig = () => {
     ],
     testRunnerHtml: (_path: any, config: { testFramework: { config?: JasmineConfig } }) => {
       const testFramework = {
-        path: './node_modules/jasmine-core/lib/jasmine-core/jasmine.js',
         config: {
           defaultTimeoutInterval: 5000,
           styles: [],
@@ -30,6 +29,7 @@ export const jasmineTestRunnerConfig = () => {
             <script type="module">
               globalThis.testFramework = {...${JSON.stringify(testFramework)}};
             </script>
+            <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
             <script type="module">
               ${fs.readFileSync(path.join(import.meta.dirname, 'framework.mjs'), 'utf8')}
             </script>


### PR DESCRIPTION
This updates jasmine-core to 6.0 and fixes incompatibilities.

jasmine-core is now loaded via plain old script tag instead of being bundled. jasmine-core isn't intended to be loaded as an ES module and historically hasn't entirely worked that way, [as you might have noticed](https://github.com/blueprintui/web-test-runner-jasmine/blob/3577495cd125eb2854f53159a67dfdc8b5287a53/src/framework.ts#L11-L12). Loading it as a plain old script fixes that. It will also avoid a deprecation warning emitted in 6.x, once [a bugfix for that warning](https://github.com/jasmine/jasmine/commit/87177d9d437c7d5113c599beba0343b043db4d66) is released. (Update: Released in jasmine-core 6.0.1.)

Jasmine's ConsoleReporter no longer runs in browsers. I vendored a copy of the ConsoleReporter from 5.13.0. That preserves the existing behavior for now. Longer term, it seems like it would be best to write something that's tailored to the intended use case.